### PR TITLE
[util] Far Cry 2: Set VendorId to Nvidia, enable apitraceMode

### DIFF
--- a/src/util/config/config.cpp
+++ b/src/util/config/config.cpp
@@ -43,6 +43,14 @@ namespace dxvk {
       { "d3d11.dcSingleUseMode",            "False" },
       { "d3d11.cachedDynamicResources",     "vi"   },
     }} },
+    /* Far Cry 2: Set vendor ID to Nvidia to avoid
+     * vegetation artifacts on Intel, and set
+     * apitrace mode to True to improve perf on all
+     * hardware.                                  */
+    { R"(\\FarCry2\.exe$)", {{
+      { "d3d9.customVendorId",              "10de" },
+      { "d3d9.apitraceMode",                "True" },
+    }} },
     /* Far Cry 3: Assumes clear(0.5) on an UNORM  *
      * format to result in 128 on AMD and 127 on  *
      * Nvidia. We assume that the Vulkan drivers  *


### PR DESCRIPTION
Set VendorId to 10de to fix vegetation artifacting issues on Intel hardware, and enable apitraceMode to improve perf universally.